### PR TITLE
Fixed incorrect member names being used for OtaTimerInterface in ota_over_mqtt_demo.c

### DIFF
--- a/source/demo-tasks/ota_over_mqtt_demo.c
+++ b/source/demo-tasks/ota_over_mqtt_demo.c
@@ -1008,9 +1008,9 @@ static void setOtaInterfaces( OtaInterfaces_t * pOtaInterfaces )
     pOtaInterfaces->os.event.send = OtaSendEvent_FreeRTOS;
     pOtaInterfaces->os.event.recv = OtaReceiveEvent_FreeRTOS;
     pOtaInterfaces->os.event.deinit = OtaDeinitEvent_FreeRTOS;
-    pOtaInterfaces->os.timer.startTimer = OtaStartTimer_FreeRTOS;
-    pOtaInterfaces->os.timer.stopTimer = OtaStopTimer_FreeRTOS;
-    pOtaInterfaces->os.timer.deleteTimer = OtaDeleteTimer_FreeRTOS;
+    pOtaInterfaces->os.timer.start = OtaStartTimer_FreeRTOS;
+    pOtaInterfaces->os.timer.stop = OtaStopTimer_FreeRTOS;
+    pOtaInterfaces->os.timer.delete = OtaDeleteTimer_FreeRTOS;
     pOtaInterfaces->os.mem.malloc = Malloc_FreeRTOS;
     pOtaInterfaces->os.mem.free = Free_FreeRTOS;
 


### PR DESCRIPTION
Fixed incorrect member names being used for OtaTimerInterface, defined in ota_os_interface.h, in ota_over_mqtt_demo.c. This was preventing the demo from compiling.