### PR TITLE
Fix compiler warnings.  No functional changes.

### DIFF
--- a/build/Cortex-M3_MPS2_QEMU_GCC/target-specific-source/CMSIS/cmsis_gcc.h
+++ b/build/Cortex-M3_MPS2_QEMU_GCC/target-specific-source/CMSIS/cmsis_gcc.h
@@ -46,9 +46,9 @@
 #ifndef   __STATIC_INLINE
   #define __STATIC_INLINE                        static inline
 #endif
-#ifndef   __STATIC_FORCEINLINE                 
+#ifndef   __STATIC_FORCEINLINE
   #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static inline
-#endif                                           
+#endif
 #ifndef   __NO_RETURN
   #define __NO_RETURN                            __attribute__((__noreturn__))
 #endif
@@ -118,53 +118,6 @@
 #endif
 
 /* #########################  Startup and Lowlevel Init  ######################## */
-
-#ifndef __PROGRAM_START
-
-/**
-  \brief   Initializes data and bss sections
-  \details This default implementations initialized all data and additional bss
-           sections relying on .copy.table and .zero.table specified properly
-           in the used linker script.
-  
- */
-__STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
-{
-  extern void _start(void) __NO_RETURN;
-  
-  typedef struct {
-    uint32_t const* src;
-    uint32_t* dest;
-    uint32_t  wlen;
-  } __copy_table_t;
-  
-  typedef struct {
-    uint32_t* dest;
-    uint32_t  wlen;
-  } __zero_table_t;
-  
-  extern const __copy_table_t __copy_table_start__;
-  extern const __copy_table_t __copy_table_end__;
-  extern const __zero_table_t __zero_table_start__;
-  extern const __zero_table_t __zero_table_end__;
-
-  for (__copy_table_t const* pTable = &__copy_table_start__; pTable < &__copy_table_end__; ++pTable) {
-    for(uint32_t i=0u; i<pTable->wlen; ++i) {
-      pTable->dest[i] = pTable->src[i];
-    }
-  }
- 
-  for (__zero_table_t const* pTable = &__zero_table_start__; pTable < &__zero_table_end__; ++pTable) {
-    for(uint32_t i=0u; i<pTable->wlen; ++i) {
-      pTable->dest[i] = 0u;
-    }
-  }
- 
-  _start();
-}
-  
-#define __PROGRAM_START           __cmsis_start
-#endif
 
 #ifndef __INITIAL_SP
 #define __INITIAL_SP              __StackTop
@@ -652,7 +605,7 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence zero is returned always in non-secure
   mode.
-  
+
   \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
   \return               PSPLIM Register value
  */
@@ -697,7 +650,7 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
   Stack Pointer Limit register hence the write is silently ignored in non-secure
   mode.
-  
+
   \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
   \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
  */
@@ -834,7 +787,7 @@ __STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
 {
 #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
      (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
-#if __has_builtin(__builtin_arm_get_fpscr) 
+#if __has_builtin(__builtin_arm_get_fpscr)
 // Re-enable using built-in when GCC has been fixed
 // || (__GNUC__ > 7) || (__GNUC__ == 7 && __GNUC_MINOR__ >= 2)
   /* see https://gcc.gnu.org/ml/gcc-patches/2017-04/msg00443.html */

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.c
@@ -43,7 +43,7 @@
 
 /*-----------------------------------------------------------*/
 
-bool Agent_MessageSend( const MQTTAgentMessageContext_t * pMsgCtx,
+bool Agent_MessageSend( MQTTAgentMessageContext_t * pMsgCtx,
                         MQTTAgentCommand_t * const * pCommandToSend,
                         uint32_t blockTimeMs )
 {
@@ -59,7 +59,7 @@ bool Agent_MessageSend( const MQTTAgentMessageContext_t * pMsgCtx,
 
 /*-----------------------------------------------------------*/
 
-bool Agent_MessageReceive( const MQTTAgentMessageContext_t * pMsgCtx,
+bool Agent_MessageReceive( MQTTAgentMessageContext_t * pMsgCtx,
                            MQTTAgentCommand_t ** pReceivedCommand,
                            uint32_t blockTimeMs )
 {

--- a/lib/FreeRTOS/mqtt-agent-interface/include/freertos_agent_message.h
+++ b/lib/FreeRTOS/mqtt-agent-interface/include/freertos_agent_message.h
@@ -63,7 +63,7 @@ struct MQTTAgentMessageContext
  *
  * @return `true` if send was successful, else `false`.
  */
-bool Agent_MessageSend( const MQTTAgentMessageContext_t * pMsgCtx,
+bool Agent_MessageSend( MQTTAgentMessageContext_t * pMsgCtx,
                         MQTTAgentCommand_t * const * pCommandToSend,
                         uint32_t blockTimeMs );
 
@@ -77,7 +77,7 @@ bool Agent_MessageSend( const MQTTAgentMessageContext_t * pMsgCtx,
  *
  * @return `true` if receive was successful, else `false`.
  */
-bool Agent_MessageReceive( const MQTTAgentMessageContext_t * pMsgCtx,
+bool Agent_MessageReceive( MQTTAgentMessageContext_t * pMsgCtx,
                            MQTTAgentCommand_t ** pReceivedCommand,
                            uint32_t blockTimeMs );
 

--- a/source/defender-tools/report_builder.c
+++ b/source/defender-tools/report_builder.c
@@ -95,14 +95,14 @@
 
 #define reportbuilderJSON_REPORT_FORMAT_PART4 \
     ","                                       \
-    "\"%s\": %lu"                              \
+    "\"%s\": %lu"                             \
     "}"                                       \
     "}"                                       \
     "},"                                      \
     "\"%s\": {"                               \
     "\"stack_high_water_mark\": ["            \
     "{"                                       \
-    "\"%s\": %lu"                              \
+    "\"%s\": %lu"                             \
     "}"                                       \
     "],"                                      \
     "\"task_numbers\": ["                     \

--- a/source/defender-tools/report_builder.c
+++ b/source/defender-tools/report_builder.c
@@ -58,15 +58,15 @@
 
 #define reportbuilderJSON_CONNECTION_OBJECT_FORMAT \
     "{"                                            \
-    "\"%s\": %u,"                                  \
-    "\"%s\": \"%u.%u.%u.%u:%u\""                   \
+    "\"%s\": %hu,"                                 \
+    "\"%s\": \"%lu.%lu.%lu.%lu:%hu\""              \
     "},"
 
 #define reportbuilderJSON_REPORT_FORMAT_PART1 \
     "{"                                       \
     "\"%s\": {"                               \
-    "\"%s\": %u,"                             \
-    "\"%s\": \"%u.%u\""                       \
+    "\"%s\": %lu,"                            \
+    "\"%s\": \"%lu.%lu\""                     \
     "},"                                      \
     "\"%s\": {"                               \
     "\"%s\": {"                               \
@@ -74,20 +74,20 @@
 
 #define reportbuilderJSON_REPORT_FORMAT_PART2 \
     ","                                       \
-    "\"%s\": %u"                              \
+    "\"%s\": %lu"                             \
     "},"                                      \
     "\"%s\": {"                               \
     "\"%s\": "
 
 #define reportbuilderJSON_REPORT_FORMAT_PART3 \
     ","                                       \
-    "\"%s\": %u"                              \
+    "\"%s\": %lu"                             \
     "},"                                      \
     "\"%s\": {"                               \
-    "\"%s\": %u,"                             \
-    "\"%s\": %u,"                             \
-    "\"%s\": %u,"                             \
-    "\"%s\": %u"                              \
+    "\"%s\": %lu,"                            \
+    "\"%s\": %lu,"                            \
+    "\"%s\": %lu,"                            \
+    "\"%s\": %lu"                             \
     "},"                                      \
     "\"%s\": {"                               \
     "\"%s\": {"                               \
@@ -95,14 +95,14 @@
 
 #define reportbuilderJSON_REPORT_FORMAT_PART4 \
     ","                                       \
-    "\"%s\": %u"                              \
+    "\"%s\": %lu"                              \
     "}"                                       \
     "}"                                       \
     "},"                                      \
     "\"%s\": {"                               \
     "\"stack_high_water_mark\": ["            \
     "{"                                       \
-    "\"%s\": %u"                              \
+    "\"%s\": %lu"                              \
     "}"                                       \
     "],"                                      \
     "\"task_numbers\": ["                     \
@@ -313,10 +313,10 @@ static eReportBuilderStatus prvWriteConnectionsArray( char * pcBuffer,
                                        DEFENDER_REPORT_LOCAL_PORT_KEY,
                                        pxConn->usLocalPort,
                                        DEFENDER_REPORT_REMOTE_ADDR_KEY,
-                                       ( pxConn->ulRemoteIp >> 24 ) & 0xFF,
-                                       ( pxConn->ulRemoteIp >> 16 ) & 0xFF,
-                                       ( pxConn->ulRemoteIp >> 8 ) & 0xFF,
-                                       ( pxConn->ulRemoteIp ) & 0xFF,
+                                       ( pxConn->ulRemoteIp >> 24 ) & 0xFFUL,
+                                       ( pxConn->ulRemoteIp >> 16 ) & 0xFFUL,
+                                       ( pxConn->ulRemoteIp >> 8 ) & 0xFFUL,
+                                       ( pxConn->ulRemoteIp ) & 0xFFUL,
                                        pxConn->usRemotePort );
 
         if( !reportbuilderSNPRINTF_SUCCESS( lCharactersWritten, ulRemainingBufferLength ) )
@@ -394,7 +394,7 @@ static eReportBuilderStatus prvWriteTaskIdsArray( char * pcBuffer,
     {
         lCharactersWritten = snprintf( pcCurrentWritePos,
                                        ulRemainingBufferLength,
-                                       "%u,",
+                                       "%lu,",
                                        pulTaskIdsArray[ i ] );
 
         if( !reportbuilderSNPRINTF_SUCCESS( lCharactersWritten, ulRemainingBufferLength ) )

--- a/source/demo-tasks/defender_demo.c
+++ b/source/demo-tasks/defender_demo.c
@@ -898,7 +898,7 @@ void prvDefenderDemoTask( void * pvParameters )
 
             if( ulNotificationValue == 0 )
             {
-            	LogInfo( ( "Failed to receive defender report receipt notification." ) );
+                LogInfo( ( "Failed to receive defender report receipt notification." ) );
             }
             else
             {

--- a/source/demo-tasks/defender_demo.c
+++ b/source/demo-tasks/defender_demo.c
@@ -896,10 +896,17 @@ void prvDefenderDemoTask( void * pvParameters )
             /* Wait for the response to our report. */
             ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( defenderexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
 
-            if( xReportStatus == ReportStatusNotReceived )
+            if( ulNotificationValue == 0 )
             {
-                LogError( ( "Failed to receive response from AWS IoT Device Defender Service." ) );
-                xStatus = false;
+            	LogInfo( ( "Failed to receive defender report receipt notification." ) );
+            }
+            else
+            {
+                if( xReportStatus == ReportStatusNotReceived )
+                {
+                    LogError( ( "Failed to receive response from AWS IoT Device Defender Service." ) );
+                    xStatus = false;
+                }
             }
 
             LogDebug( ( "Sleeping until next report." ) );

--- a/source/demo-tasks/shadow_device_task.c
+++ b/source/demo-tasks/shadow_device_task.c
@@ -789,18 +789,25 @@ void vShadowDeviceTask( void * pvParameters )
                                                    &xPublishInfo,
                                                    &xCommandParams );
 
-                /* Wait for the response to our report. When the Device shadow service receives the request it will
-                 * publish a response to  the /update/accepted or update/rejected */
-                ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
-
-                if( ulNotificationValue == 0 )
+                if( xCommandAdded != MQTTSuccess )
                 {
-                    LogError( ( "Timed out waiting for response to report." ) );
+                    LogInfo( ( "Failed to publish report to shadow." ) );
+                }
+                else
+                {
+                    /* Wait for the response to our report. When the Device shadow service receives the request it will
+                     * publish a response to  the /update/accepted or update/rejected */
+                    ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
 
-                    /* If we time out waiting for a response and then the report is accepted, the
-                     * state may be out of sync. Set the reported state as to ensure we resend the
-                     * report. */
-                    ulReportedPowerOnState = shadowexampleINVALID_POWERON_STATE;
+                    if( ulNotificationValue == 0 )
+                    {
+                        LogError( ( "Timed out waiting for response to report." ) );
+
+                        /* If we time out waiting for a response and then the report is accepted, the
+                         * state may be out of sync. Set the reported state as to ensure we resend the
+                         * report. */
+                        ulReportedPowerOnState = shadowexampleINVALID_POWERON_STATE;
+                    }
                 }
 
                 /* Clear the client token */

--- a/source/demo-tasks/shadow_update_task.c
+++ b/source/demo-tasks/shadow_update_task.c
@@ -595,15 +595,22 @@ void vShadowUpdateTask( void * pvParameters )
                                                &xPublishInfo,
                                                &xCommandParams );
 
-            /* Wait for the response to our report. When the Device shadow service receives the request it will
-             * publish a response to  the /update/accepted or update/rejected */
-            ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
-
-            if( ulNotificationValue == 0 )
+            if( xCommandAdded != MQTTSuccess )
             {
-                LogError( ( "Timed out waiting for response to report." ) );
+            	LogInfo( ( "Failed to publish to shadow update." ) );
             }
+            else
+            {
+				/* Wait for the response to our report. When the Device shadow service receives the request it will
+				 * publish a response to  the /update/accepted or update/rejected */
+				ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
 
+				if( ulNotificationValue == 0 )
+				{
+					LogError( ( "Timed out waiting for response to report." ) );
+				}
+
+            }
             /* Clear the client token */
             ulClientToken = 0;
 

--- a/source/demo-tasks/shadow_update_task.c
+++ b/source/demo-tasks/shadow_update_task.c
@@ -597,20 +597,20 @@ void vShadowUpdateTask( void * pvParameters )
 
             if( xCommandAdded != MQTTSuccess )
             {
-            	LogInfo( ( "Failed to publish to shadow update." ) );
+                LogInfo( ( "Failed to publish to shadow update." ) );
             }
             else
             {
-				/* Wait for the response to our report. When the Device shadow service receives the request it will
-				 * publish a response to  the /update/accepted or update/rejected */
-				ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
+                /* Wait for the response to our report. When the Device shadow service receives the request it will
+                 * publish a response to  the /update/accepted or update/rejected */
+                ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
 
-				if( ulNotificationValue == 0 )
-				{
-					LogError( ( "Timed out waiting for response to report." ) );
-				}
-
+                if( ulNotificationValue == 0 )
+                {
+                    LogError( ( "Timed out waiting for response to report." ) );
+                }
             }
+
             /* Clear the client token */
             ulClientToken = 0;
 

--- a/source/mqtt-agent-task.c
+++ b/source/mqtt-agent-task.c
@@ -288,7 +288,7 @@ static MQTTStatus_t prvHandleResubscribe( void );
  * @param[in] pxCommandContext Context of the initial command.
  * @param[in] pxReturnInfo The result of the command.
  */
-static void prvSubscriptionCommandCallback( void * pxCommandContext,
+static void prvSubscriptionCommandCallback( MQTTAgentCommandContext_t * pxCommandContext,
                                             MQTTAgentReturnInfo_t * pxReturnInfo );
 
 /**
@@ -601,7 +601,7 @@ static MQTTStatus_t prvHandleResubscribe( void )
 
 /*-----------------------------------------------------------*/
 
-static void prvSubscriptionCommandCallback( void * pxCommandContext,
+static void prvSubscriptionCommandCallback( MQTTAgentCommandContext_t * pxCommandContext,
                                             MQTTAgentReturnInfo_t * pxReturnInfo )
 {
     size_t lIndex = 0;
@@ -652,7 +652,7 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
             /* ALPN protocols must be a NULL-terminated list of strings. Therefore,
              * the first entry will contain the actual ALPN protocol string while the
              * second entry must remain NULL. */
-            char * pcAlpnProtocols[] = { NULL, NULL };
+            const char * pcAlpnProtocols[] = { NULL, NULL };
 
             /* The ALPN string changes depending on whether username/password authentication is used. */
             #ifdef democonfigCLIENT_USERNAME

--- a/source/subscription-manager/subscription_manager.c
+++ b/source/subscription-manager/subscription_manager.c
@@ -102,7 +102,7 @@ void removeSubscription( SubscriptionElement_t * pxSubscriptionList,
                          const char * pcTopicFilterString,
                          uint16_t usTopicFilterLength )
 {
-    int32_t lIndex = 0;
+    uint32_t ulIndex = 0;
 
     if( ( pxSubscriptionList == NULL ) ||
         ( pcTopicFilterString == NULL ) ||
@@ -116,13 +116,13 @@ void removeSubscription( SubscriptionElement_t * pxSubscriptionList,
     }
     else
     {
-        for( lIndex = 0; lIndex < SUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS; lIndex++ )
+        for( ulIndex = 0U; ulIndex < SUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS; ulIndex++ )
         {
-            if( pxSubscriptionList[ lIndex ].usFilterStringLength == usTopicFilterLength )
+            if( pxSubscriptionList[ ulIndex ].usFilterStringLength == usTopicFilterLength )
             {
-                if( strncmp( pxSubscriptionList[ lIndex ].pcSubscriptionFilterString, pcTopicFilterString, usTopicFilterLength ) == 0 )
+                if( strncmp( pxSubscriptionList[ ulIndex ].pcSubscriptionFilterString, pcTopicFilterString, usTopicFilterLength ) == 0 )
                 {
-                    memset( &( pxSubscriptionList[ lIndex ] ), 0x00, sizeof( SubscriptionElement_t ) );
+                    memset( &( pxSubscriptionList[ ulIndex ] ), 0x00, sizeof( SubscriptionElement_t ) );
                 }
             }
         }
@@ -134,7 +134,7 @@ void removeSubscription( SubscriptionElement_t * pxSubscriptionList,
 bool handleIncomingPublishes( SubscriptionElement_t * pxSubscriptionList,
                               MQTTPublishInfo_t * pxPublishInfo )
 {
-    int32_t lIndex = 0;
+    uint32_t ulIndex = 0;
     bool isMatched = false, publishHandled = false;
 
     if( ( pxSubscriptionList == NULL ) ||
@@ -146,19 +146,19 @@ bool handleIncomingPublishes( SubscriptionElement_t * pxSubscriptionList,
     }
     else
     {
-        for( lIndex = 0; lIndex < SUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS; lIndex++ )
+        for( ulIndex = 0U; ulIndex < SUBSCRIPTION_MANAGER_MAX_SUBSCRIPTIONS; ulIndex++ )
         {
-            if( pxSubscriptionList[ lIndex ].usFilterStringLength > 0 )
+            if( pxSubscriptionList[ ulIndex ].usFilterStringLength > 0 )
             {
                 MQTT_MatchTopic( pxPublishInfo->pTopicName,
                                  pxPublishInfo->topicNameLength,
-                                 pxSubscriptionList[ lIndex ].pcSubscriptionFilterString,
-                                 pxSubscriptionList[ lIndex ].usFilterStringLength,
+                                 pxSubscriptionList[ ulIndex ].pcSubscriptionFilterString,
+                                 pxSubscriptionList[ ulIndex ].usFilterStringLength,
                                  &isMatched );
 
                 if( isMatched == true )
                 {
-                    pxSubscriptionList[ lIndex ].pxIncomingPublishCallback( pxSubscriptionList[ lIndex ].pvIncomingPublishCallbackContext,
+                    pxSubscriptionList[ ulIndex ].pxIncomingPublishCallback( pxSubscriptionList[ ulIndex ].pvIncomingPublishCallbackContext,
                                                                             pxPublishInfo );
                     publishHandled = true;
                 }

--- a/source/subscription-manager/subscription_manager.c
+++ b/source/subscription-manager/subscription_manager.c
@@ -159,7 +159,7 @@ bool handleIncomingPublishes( SubscriptionElement_t * pxSubscriptionList,
                 if( isMatched == true )
                 {
                     pxSubscriptionList[ ulIndex ].pxIncomingPublishCallback( pxSubscriptionList[ ulIndex ].pvIncomingPublishCallbackContext,
-                                                                            pxPublishInfo );
+                                                                             pxPublishInfo );
                     publishHandled = true;
                 }
             }


### PR DESCRIPTION
These updates fix all the warnings other than those that require an update to the MQTT agent sub-module.  That sub-module has a mismatch in the const qualification of the first parameter in the following two prototypes:

typedef bool ( * MQTTAgentMessageSend_t )( MQTTAgentMessageContext_t * pMsgCtx,
                                           MQTTAgentCommand_t * const * pCommandToSend,
                                           uint32_t blockTimeMs );


typedef bool ( * MQTTAgentMessageRecv_t )( MQTTAgentMessageContext_t * pMsgCtx,
                                           MQTTAgentCommand_t ** pReceivedCommand,
                                           uint32_t blockTimeMs );


To fix those warnings add a const to the first parameter as below, or update the code using the prototypes to remove the const if adding the cost risks breaking other code:

typedef bool ( * MQTTAgentMessageSend_t )( **const** MQTTAgentMessageContext_t * pMsgCtx,
                                           MQTTAgentCommand_t * const * pCommandToSend,
                                           uint32_t blockTimeMs );


typedef bool ( * MQTTAgentMessageRecv_t )( **const** MQTTAgentMessageContext_t * pMsgCtx,
                                           MQTTAgentCommand_t ** pReceivedCommand,
                                           uint32_t blockTimeMs );

