### PR TITLE
Fix logging errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Ignore MacOS file system related.  
+# Ignore macOS file system related.  
 **/*.DS_Store*
 
 # Ignore build results
@@ -17,3 +17,10 @@
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Build artifacts
+*.o
+*.d
+*.a
+*.map
+*.elf

--- a/build/Cortex-M3_MPS2_QEMU_GCC/Makefile
+++ b/build/Cortex-M3_MPS2_QEMU_GCC/Makefile
@@ -27,7 +27,6 @@ CFLAGS += $(INCLUDE_DIRS) --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
 #must be the first include paths to ensure the correct FreeRTOSConfig.h is used.
 INCLUDE_DIRS += -I./target-specific-source
 INCLUDE_DIRS += -I./target-specific-source/CMSIS
-INCLUDE_DIRS += -I./../../lib/FreeRTOS/utilities/logging
 INCLUDE_DIRS += -I./../../source/configuration-files
 INCLUDE_DIRS += -I./../../lib/ThirdParty/mbedtls/include
 INCLUDE_DIRS += -I./../../lib/FreeRTOS/utilities/mbedtls_freertos

--- a/source/configuration-files/demo_config.h
+++ b/source/configuration-files/demo_config.h
@@ -27,46 +27,6 @@
 #ifndef DEMO_CONFIG_H
 #define DEMO_CONFIG_H
 
-/**************************************************/
-/******* DO NOT CHANGE the following order ********/
-/**************************************************/
-
-/* Include logging header files and define logging macros in the following order:
- * 1. Include the header file "logging_levels.h".
- * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
- * the logging configuration for DEMO.
- * 3. Include the header file "logging_stack.h", if logging is enabled for DEMO.
- */
-
-#include "logging_levels.h"
-
-/* Logging configuration for the Demo. */
-#ifndef LIBRARY_LOG_NAME
-    #define LIBRARY_LOG_NAME    "MQTTDemo"
-#endif
-
-#ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_DEBUG
-#endif
-
-/* Prototype for the function used to print to console on Windows simulator
- * of FreeRTOS.
- * The function prints to the console before the network is connected;
- * then a UDP port after the network has connected. */
-extern void vLoggingPrintf( const char * pcFormatString,
-                            ... );
-
-/* Map the SdkLog macro to the logging function to enable logging
- * on Windows simulator. */
-#ifndef SdkLog
-    #define SdkLog( message )    vLoggingPrintf message
-#endif
-
-#include "logging_stack.h"
-
-/************ End of logging configuration ****************/
-
-
 
 /* Constants that select which demos to build into the project:
  * Set the following to 1 to include the demo in the build, or 0 to exclude the

--- a/source/configuration-files/logging_config.h
+++ b/source/configuration-files/logging_config.h
@@ -28,6 +28,22 @@
 #ifndef LOGGING_CONFIG_H
 #define LOGGING_CONFIG_H
 
+/**************************************************/
+/* Helpful macros to make changing logging levels
+ * easier. */
+/**************************************************/
+#define LOG_NONE    0
+#define LOG_ERROR   1
+#define LOG_WARN    2
+#define LOG_INFO    3
+#define LOG_DEBUG   4
+/**************************************************/
+
+/*
+ * Change the following macro to set the demo logging level.
+ */
+#define LOG_LEVEL   LOG_INFO
+
 /*
  * Logging configuration.
  *
@@ -37,11 +53,6 @@
  * vLoggingPrintf() writes the log message itself before releasing the mutex.
  * These are the prototypes of the functions and the definitions of the macros
  * that call them - there is one macro per severity level.
- *
- * Commenting out the implementation of a macro will omit logging at that level.
- * For example, to remove the most verbose level of logging (DEBUG) simply
- * comment out the implementation of LogDebug() making it an empty macro as
- * shown here:"#define LogDebug( message )"
  *
  * If you want to print out additional metadata then update the
  * xLoggingPrintMetadata() function prototype and implementation so it accepts
@@ -69,9 +80,28 @@ void vLoggingInit( void );
  * of the logging and adding data such as the function that called the logging
  * macro to the logged output.
  */
-#define LogError( message )    do { xLoggingPrintMetadata( "ERROR" ); vLoggingPrintf message; } while( 0 )
-#define LogWarn( message )     do { xLoggingPrintMetadata( "WARN" ); vLoggingPrintf message; } while( 0 )
-#define LogInfo( message )     do { xLoggingPrintMetadata( "INFO" ); vLoggingPrintf message; } while( 0 )
-#define LogDebug( message )    /*do{ xLoggingPrintMetadata( "DEBUG" ); vLoggingPrintf message ;} while( 0 )*//* Uncomment to output debug level logging. */
+#if LOG_LEVEL >= LOG_ERROR
+    #define LogError( message )    do { xLoggingPrintMetadata( "ERROR" ); vLoggingPrintf message; } while( 0 )
+#else
+    #define LogError( message )
+#endif
+
+#if LOG_LEVEL >= LOG_WARN
+    #define LogWarn( message )    do { xLoggingPrintMetadata( "WARN" ); vLoggingPrintf message; } while( 0 )
+#else
+    #define LogWarn( message )
+#endif
+
+#if LOG_LEVEL >= LOG_INFO
+    #define LogInfo( message )    do { xLoggingPrintMetadata( "INFO" ); vLoggingPrintf message; } while( 0 )
+#else
+    #define LogInfo( message )
+#endif
+
+#if LOG_LEVEL >= LOG_DEBUG
+    #define LogDebug( message )    do { xLoggingPrintMetadata( "DEBUG" ); vLoggingPrintf message; } while( 0 )
+#else
+    #define LogDebug( message )
+#endif
 
 #endif /* LOGGING_CONFIG_H */

--- a/source/configuration-files/logging_config.h
+++ b/source/configuration-files/logging_config.h
@@ -29,20 +29,21 @@
 #define LOGGING_CONFIG_H
 
 /**************************************************/
+
 /* Helpful macros to make changing logging levels
  * easier. */
 /**************************************************/
-#define LOG_NONE    0
-#define LOG_ERROR   1
-#define LOG_WARN    2
-#define LOG_INFO    3
-#define LOG_DEBUG   4
+#define LOG_NONE     0
+#define LOG_ERROR    1
+#define LOG_WARN     2
+#define LOG_INFO     3
+#define LOG_DEBUG    4
 /**************************************************/
 
 /*
  * Change the following macro to set the demo logging level.
  */
-#define LOG_LEVEL   LOG_INFO
+#define LOG_LEVEL    LOG_DEBUG
 
 /*
  * Logging configuration.

--- a/source/mqtt-agent-task.c
+++ b/source/mqtt-agent-task.c
@@ -153,7 +153,7 @@
  * @brief Timeout for receiving CONNACK after sending an MQTT CONNECT packet.
  * Defined in milliseconds.
  */
-#define mqttexampleCONNACK_RECV_TIMEOUT_MS           ( 1000U )
+#define mqttexampleCONNACK_RECV_TIMEOUT_MS           ( 2000U )
 
 /**
  * @brief The maximum number of retries for network operation with server.


### PR DESCRIPTION
*Description*:
Fixes build errors due to some lines in `demo_config.h` that were not deleted in #53. Updates the connack receive timeout as it wasn't enough for QEMU, and introduces some logging level macros to make changing log levels easier.

